### PR TITLE
Fix configuration parameter parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributing guide
 - Continuous Integration test suite
 
+### Fixed
+
+- Configuration parameter parsing in run_isort
+
 ## [0.1.0] - 2020-10-04
 
 ### Added

--- a/bin/run_isort
+++ b/bin/run_isort
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 
-configuration=$1
-sort_paths=$2
-
-echo "Running isort $configuration $sort_paths"
-isort_result=$(isort "$configuration" "$sort_paths")
+echo "Running isort $*"
+isort_result=$(isort "$@")
 exit_code=$?
 
 echo "::set-output name=isort-output::${isort_result}"


### PR DESCRIPTION
Replace explicit parameter list by `$*`/`$@` to make sure multiple configuration parameters are parsed correctly.

Fixes: #6