### PR TITLE
Use enviroment files instead of deprecated set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
 outputs:
   isort-result:
     description: isort result
-    value: ${{ env.isort-output }}
+    value: ${{ steps.run-isort.outputs.isort-output }}
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
 outputs:
   isort-result:
     description: isort result
-    value: ${{ steps.run-isort.outputs.isort-output }}
+    value: ${{ env.isort-output }}
 
 runs:
   using: composite

--- a/bin/run_isort
+++ b/bin/run_isort
@@ -4,5 +4,5 @@ echo "Running isort $*"
 isort_result=$(isort "$@")
 exit_code=$?
 
-echo "::set-output name=isort-output::${isort_result}"
+echo "isort-output=${isort_result}" >> $GITHUB_ENV
 exit $exit_code

--- a/bin/run_isort
+++ b/bin/run_isort
@@ -4,5 +4,5 @@ echo "Running isort $*"
 isort_result=$(isort "$@")
 exit_code=$?
 
-echo "isort-output=${isort_result}" >> $GITHUB_ENV
+echo "isort-output=${isort_result}" >> "${GITHUB_OUTPUT}"
 exit $exit_code


### PR DESCRIPTION
Due to the deprecation of `set-output` it is now recommended to use [environment files](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). Examples here:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files