### PR TITLE
Encourage the use of a semantic version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: isort/isort-action@master
+      - uses: isort/isort-action@v1
         with:
             requirementsFiles: "requirements.txt requirements-test.txt"
 ```


### PR DESCRIPTION
The project should encourage users to pin the action to a semantic version. Doing so helps to ensure potential breaking changes don't immediately break a user's workflow.

All of the official GitHub actions follow this pattern as well as many other community actions:

https://github.com/actions/

For example, the checkout action: https://github.com/actions/checkout