### PR TITLE
Use GitHub actions conventional hyphen for input names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -7,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- All inputs changed to use kebab-case: `isort-version`, `sort-paths`, and
+  `requirements-files`. The old camelCase arguments will continue to work for
+  backward compatibility.
 
 ## [1.0.0] - 2022-06-01
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ It requires that the [`checkout`][github-checkout] action be used first.
 
 ## Inputs
 
-### `isortVersion`
+### `isort-version`
 
 Optional. Version of `isort` to use. Defaults to latest version of `isort`.
 
-### `sortPaths`
+### `sort-paths`
 
 Optional. List of paths to sort, relative to your project root. Defaults to `.`
 
@@ -18,7 +18,7 @@ Optional. List of paths to sort, relative to your project root. Defaults to `.`
 
 Optional. `isort` configuration options to pass to the `isort` CLI. Defaults to `--check-only --diff`.
 
-### `requirementsFiles`
+### `requirements-files`
 
 Optional. Paths to python requirements files to install before running isort.
 If multiple requirements files are provided, they should be separated by a space.
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: isort/isort-action@v1.0.0
         with:
-            requirementsFiles: "requirements.txt requirements-test.txt"
+            requirements-files: "requirements.txt requirements-test.txt"
 ```
 
 ## Developing

--- a/action.yml
+++ b/action.yml
@@ -6,22 +6,59 @@ branding:
   color: blue
 
 inputs:
-  isortVersion:
+  isort-version:
     description: Version of isort to use
     required: false
+    # Use default null to fallback to isortVersion with the expression:
+    #
+    #    ${{ inputs.isort-version || inputs.isortVersion }}
+    #
+    # TODO: Change to latest when dropping support for isortVersion.
+    default: null
+
+  isortVersion:
+    description: >
+      Version of isort to use (DEPRECATED: use isort-version instead)
+    required: false
     default: latest
-  sortPaths:
+
+  sort-paths:
     description: files or directories to sort
     required: false
+    # Use default null to fallback to sortPaths with the expression:
+    #
+    #     ${{ inputs.sort-paths || inputs.sortPaths }}
+    #
+    # TODO: Change to . when dropping support for sortPaths.
+    default: null
+
+  sortPaths:
+    description: >
+      files or directories to sort (DEPRECATED: use sort-paths instead)
+    required: false
     default: .
+
   configuration:
     description: isort configuration options
     required: false
     default: --check-only --diff
-  requirementsFiles:
-    description:
+
+  requirements-files:
+    description: >
       path(s) to requirements files that should be installed to properly
       configure third-party imports
+    required: false
+    # Use default null to fallback to requirementsFiles with the expression:
+    #
+    #     ${{ inputs.requirements-files || inputs.requirementsFiles }}
+    #
+    # TODO: Change to "" when dropping support for requirementsFiles.
+    default: null
+
+  requirementsFiles:
+    description: >
+      path(s) to requirements files that should be installed to properly
+      configure third-party imports (DEPRECATED: use requirement-files instead)
     required: false
     default: ""
 
@@ -35,12 +72,12 @@ runs:
   steps:
     - run: ${{ github.action_path }}/bin/ensure_python
       shell: bash
-    - run:
-        ${{ github.action_path }}/bin/install_packages ${{ inputs.isortVersion
-        }} ${{ inputs.requirementsFiles }}
+    - run: >
+        ${{ github.action_path }}/bin/install_packages
+        ${{ inputs.isort-version || inputs.isortVersion }}
+        ${{ inputs.requirements-files || inputs.requirementsFiles }}
       shell: bash
     - id: run-isort
       run:
-        ${{ github.action_path }}/bin/run_isort ${{ inputs.configuration }} ${{
-        inputs.sortPaths }}
+        ${{ github.action_path }}/bin/run_isort ${{ inputs.configuration }} ${{ inputs.sort-paths || inputs.sortPaths }}
       shell: bash


### PR DESCRIPTION
Looking through the GitHub workflow docs, all arguments use a kebab-case, not camelCase. As well all of the default actions use kebab-case, for example, checkout:

https://github.com/actions/checkout

Follow community conventions.

The old camelCase arguments will continue to work for backward compatibility. These arguments are now marked as deprecated and should eventually be removed in a future version.