### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: isort/isort-action@v1.0.0
+      - uses: isort/isort-action@v1
         with:
             requirements-files: "requirements.txt requirements-test.txt"
 ```


### PR DESCRIPTION
In the example, set the `isort/isort-action` version to `@v1` instead of `@v1.0.0` which is old and broken.