### PR TITLE
Support running on MacOS Runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - id: imports-properly-sorted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A [problem matcher](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) so you can see issues without trawling through logs
 
+### Changed
+
+- Update plugin to be POSIX-compliant to support usage on MacOS runners
+
 ### Fixed
 
 - Packages are installed into a virtualenv due to the fact that system-wide

--- a/bin/run_isort
+++ b/bin/run_isort
@@ -11,7 +11,20 @@ exit_code=$?
 # output to be on a single line, so a (random) delimiter needs to be used
 # so that the output is parsed properly.
 # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-DELIMITER=$(echo $RANDOM | md5sum | head -c 20)
+# POSIX-compliant: see https://stackoverflow.com/a/50435453
+DELIMITER=$(
+    awk '
+    BEGIN {
+        srand();
+        chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        s = "";
+        for(i=0;i<8;i++) {
+            s = s "" substr(chars, int(rand()*62), 1);
+        }
+        print s
+    }
+    '
+)
 {
     echo "isort-output<<${DELIMITER}"
     echo "${isort_result}"


### PR DESCRIPTION
Fix #63

Start running the plugin's CI on MacOS to catch any regressions. Note that CI failed in the first commit and is passing following the fix.